### PR TITLE
Builds edit feature

### DIFF
--- a/src/pages/Builds.jsx
+++ b/src/pages/Builds.jsx
@@ -22,6 +22,7 @@ const Builds = () => {
         // Get builds from API
         const response = await api.get('/builds');
         setBuilds(response.data.data);
+        
       } catch (err) {
         console.error('Error fetching builds:', err);
         setError('Failed to load your Pokémon builds');
@@ -99,10 +100,8 @@ const Builds = () => {
               <div className="pokedex-image-container">
                 <img
                   className="pokemon-image"
-                  src={`https://img.pokemondb.net/artwork/${build.species.toLowerCase()}.jpg`}
-                  alt={'image of ' + build.species}
-                  onError={e => { e.target.onerror = null; e.target.src = '/fallback.svg'; }}
-                />
+                  src={`https://play.pokemonshowdown.com/sprites/ani/${build.species.toLowerCase()}.gif`}
+                  alt={'image of ' + build.species}/>
               </div>
               
               <div className="pokedex-info">
@@ -110,7 +109,7 @@ const Builds = () => {
                 <h4 className="pokemon-species">{capitalize(build.species)}</h4>
                 
                 <div className="pokedex-details">
-                  <div className="pokedex-types">
+                  <div className="pokedex-types"> 
                     <span className="pokemon-nature">Nature: {capitalize(build.nature || '')}</span>
                     <span className="pokemon-ability">Ability: {capitalize(build.ability || '')}</span>
                   </div>
@@ -119,45 +118,45 @@ const Builds = () => {
                   <div className="stat-bar">
                     <span className="stat-label">HP</span>
                     <div className="stat-bar-container">
-                      <div className="stat-fill" style={{width: `${(build.stats.hp / 255) * 100}%`}}></div>
+                      <div className="stat-fill stat-fill-hp" style={{width: `${(build.stats.hp / 255) * 100}%`}}></div>
                       <span className="stat-value">{build.stats.hp}</span>
                     </div>
                   </div>
                   <div className="stat-bar">
                     <span className="stat-label">ATK</span>
                     <div className="stat-bar-container">
-                      <div className="stat-fill" style={{width: `${(build.stats.attack / 255) * 100}%`}}></div>
+                      <div className="stat-fill stat-fill-attack" style={{width: `${(build.stats.attack / 255) * 100}%`}}></div>
                       <span className="stat-value">{build.stats.attack}</span>
                     </div>
                   </div>
                   <div className="stat-bar">
                     <span className="stat-label">DEF</span>
                     <div className="stat-bar-container">
-                      <div className="stat-fill" style={{width: `${(build.stats.defense / 255) * 100}%`}}></div>
+                      <div className="stat-fill stat-fill-defense" style={{width: `${(build.stats.defense / 255) * 100}%`}}></div>
                       <span className="stat-value">{build.stats.defense}</span>
                     </div>
                   </div>
-                    {/* <div className="stat-bar">
+                    <div className="stat-bar">
                       <span className="stat-label">SP-A</span>
                       <div className="stat-bar-container">
-                        <div className="stat-fill" style={{width: `${(build.stats.specialAttack / 255) * 100}%`}}></div>
+                        <div className="stat-fill stat-fill-special-attack" style={{width: `${(build.stats.specialAttack / 255) * 100}%`}}></div>
                         <span className="stat-value">{build.stats.specialAttack}</span>
                       </div>
                     </div>
                     <div className="stat-bar">
                       <span className="stat-label">SP-D</span>
                       <div className="stat-bar-container">
-                        <div className="stat-fill" style={{width: `${(build.stats.specialDefense / 255) * 100}%`}}></div>
+                        <div className="stat-fill stat-fill-special-defense" style={{width: `${(build.stats.specialDefense / 255) * 100}%`}}></div>
                         <span className="stat-value">{build.stats.specialDefense}</span>
                       </div>
                     </div>
                     <div className="stat-bar">
                       <span className="stat-label">SPEED</span>
                       <div className="stat-bar-container">
-                        <div className="stat-fill" style={{width: `${(build.stats.speed / 255) * 100}%`}}></div>
+                        <div className="stat-fill stat-fill-speed" style={{width: `${(build.stats.speed / 255) * 100}%`}}></div>
                         <span className="stat-value">{build.stats.speed}</span>
                       </div>
-                    </div> */}
+                    </div>
                   </div>
                 </div>
                 

--- a/src/pages/Builds.jsx
+++ b/src/pages/Builds.jsx
@@ -176,12 +176,12 @@ const Builds = () => {
               </div>
               
               <div className="pokedex-buttons">
-                <button className="edit-button">Edit</button>
+                <Link to={`/builds/${build._id}/edit`} className="edit-button">Edit</Link>
                 <button 
                   className="delete-button" 
                   onClick={() => handleDeleteBuild(build._id)} 
                 >×</button>
-                </div>
+              </div>
               
             </div>
           ))}

--- a/src/pages/EditBuild.jsx
+++ b/src/pages/EditBuild.jsx
@@ -60,6 +60,7 @@ const EditBuild = () => {
           setLoading(false);
         }
       };
+      
       fetchBuild();
     }, [id]);
 
@@ -212,7 +213,10 @@ return (
         <div id="moves" name="moves" style={{ maxHeight: '150px', maxWidth: '300px', overflow: 'auto', border: '1px solid #ccc', padding: '0.5rem' }}>
           {availableMoves.map((move) => (
             <label key={move} htmlFor={`move-${move}`}>
-              <input id={`move-${move}`} type="checkbox" disabled={moves.length >= 4 && !moves.includes(move)} onChange={(e) => handleMoveToggle(move)} />
+              <input id={`move-${move}`} type="checkbox"
+              checked={moves.includes(move)} 
+              disabled={moves.length >= 4 && !moves.includes(move)}
+              onChange={(e) => handleMoveToggle(move)} />
               {move}
             </label>
           ))}

--- a/src/pages/EditBuild.jsx
+++ b/src/pages/EditBuild.jsx
@@ -105,6 +105,7 @@ const EditBuild = () => {
             break;
         }
       });
+
       setStats(statObj);
     } catch (e) {
       setError(e.message);
@@ -157,15 +158,13 @@ const EditBuild = () => {
 return (
     <div className="auth-container">
   <div className="auth-card">
-    <h2>Edit Pokémon Build</h2>
-    <img
-                  className="pokemon-image"
-                  src={`https://img.pokemondb.net/artwork/${species.toLowerCase()}.jpg`}
-                  alt={'image of ' + species}
-                  onError={e => { e.target.onerror = null; e.target.src = '/fallback.svg'; }}
-                />
+    <h2>Edit {nickname}</h2>
     <form className="auth-form" onSubmit={handleSubmit}>
-      
+    <img
+        className="pokemon-image"
+        src={`https://play.pokemonshowdown.com/sprites/ani/${species.toLowerCase()}.gif`}
+        alt={'image of ' + species}        
+        ></img>
       <div className="error-message">{error}</div>
 
       <div className="form-group">
@@ -220,18 +219,50 @@ return (
         </div>
       </div>
 
-      <div className="form-group">
-        <p className="form-group-label">Base Stats</p>
-        <ul id="stats" name="stats" style={{ listStyle: 'none', padding: '0' }}>
-          <li>HP: {stats?.hp}</li>
-          <li>Attack: {stats?.attack}</li>
-          <li>Defense: {stats?.defense}</li>
-          <li>Sp. Atk: {stats?.specialAttack}</li>
-          <li>Sp. Def: {stats?.specialDefense}</li>
-          <li>Speed: {stats?.speed}</li>
-        </ul>
-      </div>
-
+      <div className="pokedex-stats">
+                  <div className="stat-bar">
+                    <span className="stat-label">HP</span>
+                    <div className="stat-bar-container">
+                      <div className="stat-fill stat-fill-hp" style={{width: `${(stats?.hp / 255) * 100}%`}}></div>
+                      <span className="stat-value">{stats?.hp}</span>
+                    </div>
+                  </div>
+                  <div className="stat-bar">
+                    <span className="stat-label">ATK</span>
+                    <div className="stat-bar-container">
+                      <div className="stat-fill stat-fill-attack" style={{width: `${(stats?.attack / 255) * 100}%`}}></div>
+                      <span className="stat-value">{stats?.attack}</span>
+                    </div>
+                  </div>
+                  <div className="stat-bar">
+                    <span className="stat-label">DEF</span>
+                    <div className="stat-bar-container">
+                      <div className="stat-fill stat-fill-defense" style={{width: `${(stats?.defense / 255) * 100}%`}}></div>
+                      <span className="stat-value">{stats?.defense}</span>
+                    </div>
+                  </div>
+                    <div className="stat-bar">
+                      <span className="stat-label">SP-A</span>
+                      <div className="stat-bar-container">
+                        <div className="stat-fill stat-fill-special-attack" style={{width: `${(stats?.specialAttack / 255) * 100}%`}}></div>
+                        <span className="stat-value">{stats?.specialAttack}</span>
+                      </div>
+                    </div>
+                    <div className="stat-bar">
+                      <span className="stat-label">SP-D</span>
+                      <div className="stat-bar-container">
+                        <div className="stat-fill stat-fill-special-defense" style={{width: `${(stats?.specialDefense / 255) * 100}%`}}></div>
+                        <span className="stat-value">{stats?.specialDefense}</span>
+                      </div>
+                    </div>
+                    <div className="stat-bar">
+                      <span className="stat-label">SPEED</span>
+                      <div className="stat-bar-container">
+                        <div className="stat-fill stat-fill-speed" style={{width: `${(stats?.speed / 255) * 100}%`}}></div>
+                        <span className="stat-value">{stats?.speed}</span>
+                      </div>
+                    </div>
+                  </div>
       <button type="submit" className="submit-button">Save Build</button>
     </form>
 

--- a/src/pages/EditBuild.jsx
+++ b/src/pages/EditBuild.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { useNavigate, Link, useParams } from "react-router-dom";
 import { useAuth } from "../provider/authProvider";
 import api from "../services/api";
-import "../styles/auth.css"; 
+import "../styles/EditBuild.css"; 
 
 // List of Pokémon natures
 const NATURES = [
@@ -158,6 +158,12 @@ return (
     <div className="auth-container">
   <div className="auth-card">
     <h2>Edit Pokémon Build</h2>
+    <img
+                  className="pokemon-image"
+                  src={`https://img.pokemondb.net/artwork/${species.toLowerCase()}.jpg`}
+                  alt={'image of ' + species}
+                  onError={e => { e.target.onerror = null; e.target.src = '/fallback.svg'; }}
+                />
     <form className="auth-form" onSubmit={handleSubmit}>
       
       <div className="error-message">{error}</div>

--- a/src/pages/EditBuild.jsx
+++ b/src/pages/EditBuild.jsx
@@ -13,7 +13,7 @@ const NATURES = [
     "Calm","Gentle","Sassy","Careful","Quirky"
   ];
 
-const CreateBuild = () => {
+const EditBuild = () => {
     const { token } = useAuth();
     const navigate = useNavigate();
 
@@ -23,15 +23,14 @@ const CreateBuild = () => {
     const [ability, setAbility] = useState("");
     const [moves, setMoves] = useState([]);
     const [stats, setStats] = useState(null);
-    // const [search, setSearch] = useState("");
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState("");
+    const [species, setSpecies] = useState("");
 
     //data fetched from pokeAPI
     const [availableAbilities, setAvailableAbilities] = useState([]);
     const [availableMoves, setAvailableMoves] = useState([]);
     const [heldItems, setHeldItems] = useState([]);
-    const [species, setSpecies] = useState("");
     const { id} = useParams();
 
 
@@ -65,7 +64,7 @@ const CreateBuild = () => {
     }, [id]);
 
     //fetch pokemon data from pokeAPI
-    const fetchPokemon = async () => {
+    const fetchPokemon = async (species) => {
         if (!species) return;
         try {
             setLoading(true);
@@ -158,17 +157,14 @@ const CreateBuild = () => {
 return (
     <div className="auth-container">
   <div className="auth-card">
-    <h2>Create Pokémon Build</h2>
+    <h2>Edit Pokémon Build</h2>
     <form className="auth-form" onSubmit={handleSubmit}>
       
       <div className="error-message">{error}</div>
 
       <div className="form-group">
-        <label htmlFor="search">Search Species</label>
-        <div style={{ display: 'flex', gap: '0.5rem' }}>
-          <input id="search" placeholder="e.g. pikachu" onChange={(e) => setSpecies(e.target.value)} />
-          <button type="button" onClick={fetchPokemon}>Search</button>
-        </div>
+        <label htmlFor="species">Species</label>
+        <input id="species" placeholder="e.g. pikachu" value={species} />
       </div>
 
       <div className="form-group">
@@ -243,4 +239,4 @@ return (
 
 }
 
-export default CreateBuild;
+export default EditBuild;

--- a/src/pages/EditBuild.jsx
+++ b/src/pages/EditBuild.jsx
@@ -1,0 +1,246 @@
+import { useState, useEffect } from "react";
+import { useNavigate, Link, useParams } from "react-router-dom";
+import { useAuth } from "../provider/authProvider";
+import api from "../services/api";
+import "../styles/auth.css"; 
+
+// List of Pokémon natures
+const NATURES = [
+    "Hardy","Lonely","Brave","Adamant","Naughty",
+    "Bold","Docile","Relaxed","Impish","Lax",
+    "Timid","Hasty","Serious","Jolly","Naive",
+    "Modest","Mild","Quiet","Bashful","Rash",
+    "Calm","Gentle","Sassy","Careful","Quirky"
+  ];
+
+const CreateBuild = () => {
+    const { token } = useAuth();
+    const navigate = useNavigate();
+
+    const [nickname, setNickname] = useState("");
+    const [nature, setNature] = useState("");
+    const [item, setItem] = useState("");
+    const [ability, setAbility] = useState("");
+    const [moves, setMoves] = useState([]);
+    const [stats, setStats] = useState(null);
+    // const [search, setSearch] = useState("");
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState("");
+
+    //data fetched from pokeAPI
+    const [availableAbilities, setAvailableAbilities] = useState([]);
+    const [availableMoves, setAvailableMoves] = useState([]);
+    const [heldItems, setHeldItems] = useState([]);
+    const [species, setSpecies] = useState("");
+    const { id} = useParams();
+
+
+    useEffect(() => {
+      const fetchBuild = async () => {
+        try {
+          setLoading(true);
+          setError("");
+  
+          api.defaults.headers.common["Authorization"] = `Bearer ${token}`;
+          const res = await api.get(`/builds/${id}`);
+          const build = res.data.data;
+  
+          setNickname(build.nickname || "");
+          setNature(build.nature || "");
+          setItem(build.item || "");
+          setAbility(build.ability || "");
+          setMoves(build.moves || []);
+          setStats(build.stats || {});
+          setSpecies(build.species || "");
+  
+          // Fetch Pokémon data for abilities, moves, stats
+          await fetchPokemon(build.species);
+        } catch (e) {
+          setError("Failed to load build. Please try again.");
+        } finally {
+          setLoading(false);
+        }
+      };
+      fetchBuild();
+    }, [id]);
+
+    //fetch pokemon data from pokeAPI
+    const fetchPokemon = async () => {
+        if (!species) return;
+        try {
+            setLoading(true);
+            setError("");
+            const res = await fetch(`https://pokeapi.co/api/v2/pokemon/${species.toLowerCase()}`);
+            if (!res.ok) throw new Error("Pokémon not found!");
+            const data = await res.json();
+            
+            //set returned pokemon data
+            setSpecies(data.species.name);
+            setAvailableAbilities(data.abilities.map((a) => a.ability.name));
+            setAvailableMoves(data.moves.map((m) => m.move.name));
+            setHeldItems(data.held_items.map((h) => h.item.name));
+
+            // Map stats to schema
+            const statObj = {};
+            data.stats.forEach((s) => {
+        switch (s.stat.name) {
+          case "hp":
+            statObj.hp = s.base_stat;
+            break;
+          case "attack":
+            statObj.attack = s.base_stat;
+            break;
+          case "defense":
+            statObj.defense = s.base_stat;
+            break;
+          case "special-attack":
+            statObj.specialAttack = s.base_stat;
+            break;
+          case "special-defense":
+            statObj.specialDefense = s.base_stat;
+            break;
+          case "speed":
+            statObj.speed = s.base_stat;
+            break;
+          default:
+            break;
+        }
+      });
+      setStats(statObj);
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+    // Toggle move selection (max 4)
+    const handleMoveToggle = (moveName) => {
+        setMoves((prevMoves) => {
+          if (prevMoves.includes(moveName)) {
+            return prevMoves.filter((m) => m !== moveName);
+          }
+          if (prevMoves.length >= 4) return prevMoves; // max 4 moves
+          return [...prevMoves, moveName];
+        });
+      };
+
+      const handleSubmit = async (e) => {
+        e.preventDefault();
+        
+        try {
+          setLoading(true);
+          setError("");
+          
+          // Configure auth header
+          api.defaults.headers.common['Authorization'] = `Bearer ${token}`;
+          
+          // Send build data to API
+          await api.put(`/builds/${id}`, {
+            nickname,
+            species,
+            nature,
+            item,
+            ability,
+            moves,
+            stats
+          });
+          
+          // Redirect to builds page
+          navigate('/builds');
+        } catch (e) {
+          setError(e.message);
+        } finally {
+          setLoading(false);
+        }
+      }
+
+return (
+    <div className="auth-container">
+  <div className="auth-card">
+    <h2>Create Pokémon Build</h2>
+    <form className="auth-form" onSubmit={handleSubmit}>
+      
+      <div className="error-message">{error}</div>
+
+      <div className="form-group">
+        <label htmlFor="search">Search Species</label>
+        <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <input id="search" placeholder="e.g. pikachu" onChange={(e) => setSpecies(e.target.value)} />
+          <button type="button" onClick={fetchPokemon}>Search</button>
+        </div>
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="nickname">Nickname</label>
+        <input id="nickname" name="nickname" placeholder="Optional" value={nickname} onChange={(e) => setNickname(e.target.value)}/>
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="nature">Nature *</label>
+        <select id="nature" name="nature" required value={nature} onChange={(e) => setNature(e.target.value)}>
+            <option value="">Select nature</option>
+        {NATURES.map((nature) => (
+          <option key={nature} value={nature}>{nature}</option>
+        ))}
+        </select>
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="ability">Ability *</label>
+        <select id="ability" name="ability" required value={ability} onChange={(e) => setAbility(e.target.value)}>
+          <option value="">Select ability</option>
+          {availableAbilities.map((ability) => (
+            <option key={ability} value={ability}>{ability}</option>
+          ))}
+        </select>
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="item">Held Item</label>
+        <select id="item" name="item" value={item} onChange={(e) => setItem(e.target.value)}>
+          <option value="">None</option>
+          {heldItems.map((item) => (
+            <option key={item} value={item}>{item}</option>
+          ))}
+        </select>
+      </div>
+
+      <div className="form-group">
+        <p className="form-group-label">Moves (max 4) *</p>
+        <div id="moves" name="moves" style={{ maxHeight: '150px', maxWidth: '300px', overflow: 'auto', border: '1px solid #ccc', padding: '0.5rem' }}>
+          {availableMoves.map((move) => (
+            <label key={move} htmlFor={`move-${move}`}>
+              <input id={`move-${move}`} type="checkbox" disabled={moves.length >= 4 && !moves.includes(move)} onChange={(e) => handleMoveToggle(move)} />
+              {move}
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div className="form-group">
+        <p className="form-group-label">Base Stats</p>
+        <ul id="stats" name="stats" style={{ listStyle: 'none', padding: '0' }}>
+          <li>HP: {stats?.hp}</li>
+          <li>Attack: {stats?.attack}</li>
+          <li>Defense: {stats?.defense}</li>
+          <li>Sp. Atk: {stats?.specialAttack}</li>
+          <li>Sp. Def: {stats?.specialDefense}</li>
+          <li>Speed: {stats?.speed}</li>
+        </ul>
+      </div>
+
+      <button type="submit" className="submit-button">Save Build</button>
+    </form>
+
+    <div className="auth-footer">
+      <a href="/builds" onClick={() => navigate("/builds")}>← Back to Builds</a>
+    </div>
+  </div>
+</div>
+
+  );
+
+}
+
+export default CreateBuild;

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -9,6 +9,7 @@ import Register from "../pages/Register";
 import Dashboard from "../pages/Dashboard"; 
 import Builds from "../pages/Builds";
 import CreateBuild from "../pages/CreateBuild";
+import EditBuild from "../pages/EditBuild";
 
 const Routes = () => {
   const { token } = useAuth();
@@ -42,6 +43,7 @@ const Routes = () => {
             { path: "dashboard", element: <Dashboard /> },
             { path: "builds", element: <Builds /> },
             { path: "builds/create", element: <CreateBuild /> },
+            { path: "builds/:id/edit", element: <EditBuild /> },
             { path: "logout", element: <Logout /> },
             
           ],

--- a/src/styles/Builds.css
+++ b/src/styles/Builds.css
@@ -40,6 +40,16 @@
     transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
     overflow: hidden; 
   }
+
+  .pokemon-image {
+    width: 100%;
+    height: auto;    
+    max-width: 120px;       
+    width: 100%;                     
+    image-rendering: pixelated; 
+    display: block;        
+    margin: 0 auto;
+  }
   
   .pokedex-card:hover {
     transform: translateY(-5px);
@@ -132,12 +142,12 @@
   }
   
   /*Color-coded stats */
-  .stat-bar:nth-child(1) .stat-fill { background-color: #f87171; } /* HP  */
-  .stat-bar:nth-child(2) .stat-fill { background-color: #fb923c; } /* ATK  */
-  .stat-bar:nth-child(3) .stat-fill { background-color: #60a5fa; } /* DEF  */
-  .stat-bar:nth-child(4) .stat-fill { background-color: #a78bfa; } /* SP-A  */
-  .stat-bar:nth-child(5) .stat-fill { background-color: #4ade80; } /* SP-D  */
-  .stat-bar:nth-child(6) .stat-fill { background-color: #facc15; } /* SPEED  */
+  .stat-fill-hp { background-color: #f87171; } /* HP  */
+  .stat-fill-attack { background-color: #fb923c; } /* ATK  */
+  .stat-fill-defense { background-color: #60a5fa; } /* DEF  */
+  .stat-fill-special-attack { background-color: #a78bfa; } /* SP-A  */
+  .stat-fill-special-defense { background-color: #4ade80; } /* SP-D  */
+  .stat-fill-speed { background-color: #facc15; } /* SPEED  */
   
   
   /*  Moves  */
@@ -271,3 +281,4 @@
       grid-template-columns: 1fr;
     }
   }
+

--- a/src/styles/EditBuild.css
+++ b/src/styles/EditBuild.css
@@ -1,7 +1,13 @@
 @import url('./auth.css');
 
 .pokemon-image {
-    width: 10rem;
-    height: 10rem;
-    object-fit: cover;
+    width: 100%;
+    height: auto;    
+    max-width: 120px;       
+    width: 100%;                     
+    image-rendering: pixelated; 
+    display: block;        
+    margin: 0 auto;
 }
+
+

--- a/src/styles/EditBuild.css
+++ b/src/styles/EditBuild.css
@@ -1,0 +1,7 @@
+@import url('./auth.css');
+
+.pokemon-image {
+    width: 10rem;
+    height: 10rem;
+    object-fit: cover;
+}


### PR DESCRIPTION
 Summary

Implements full Edit Build feature for Pokémon builds.

- Created `EditBuild` component with prefilled form data
- Integrated API fetch/update logic using build ID
- Added animated sprite rendering for the Pokémon
- Refactored the builds list to link to edit page via `Link`
- Updated checkbox logic to reflect and limit selected moves (max 4)
- Applied style updates for stat bars and responsive image display

Functionality

- Loads existing build data via `/builds/:id`
- Users can modify nickname, nature, ability, item, and moves
- Supports up to 4 moves per build
- Saves changes to backend via PUT request
- Redirects back to `/builds` on success

 Notes

- All changes tested locally
- Styling consistent with CreateBuild flow
- Route `/builds/:id/edit` added in router

Closes #19