### PR TITLE
feat: add team management pages with CRUD functionality and styling

### DIFF
--- a/src/pages/CreateTeam.jsx
+++ b/src/pages/CreateTeam.jsx
@@ -1,0 +1,207 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../provider/authProvider';
+import api from '../services/api';
+import '../styles/CreateTeam.css';
+import '../styles/Builds.css';
+
+const CreateTeam = () => {
+  const { token } = useAuth();
+  const navigate = useNavigate();
+
+  const [name, setName] = useState('');
+  const [availableBuilds, setAvailableBuilds] = useState([]);
+  const [selectedBuilds, setSelectedBuilds] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchBuilds = async () => {
+      try {
+        setLoading(true);
+        api.defaults.headers.common['Authorization'] = `Bearer ${token}`;
+        const res = await api.get('/builds');
+        setAvailableBuilds(res.data.data);
+      } catch (err) {
+        console.error(err);
+        setError('Failed to load your builds');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchBuilds();
+  }, [token]);
+
+  const toggleSelect = (buildId) => {
+    setSelectedBuilds((prev) => {
+      if (prev.includes(buildId)) {
+        return prev.filter((id) => id !== buildId);
+      }
+      if (prev.length >= 6) return prev; // max 6
+      return [...prev, buildId];
+    });
+  };
+
+  const getSpriteUrl = (species) =>
+    `https://play.pokemonshowdown.com/sprites/ani/${species.toLowerCase()}.gif`;
+
+  // Capitalize helper
+  const capitalize = (str) => {
+    if (!str) return 'Unknown';
+    return str.charAt(0).toUpperCase() + str.slice(1);
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!name.trim()) {
+      alert('Team name required');
+      return;
+    }
+    if (selectedBuilds.length === 0) {
+      alert('Select at least one Pokémon build');
+      return;
+    }
+    try {
+      setLoading(true);
+      await api.post('/teams', {
+        name,
+        pokemonBuilds: selectedBuilds,
+      });
+      navigate('/teams');
+    } catch (err) {
+      console.error(err);
+      setError('Failed to create team');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="loading-container">
+        <div className="loading-spinner"></div>
+        <p>Loading...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="create-team-container">
+      <h2>Create New Team</h2>
+      {error && <p className="error">{error}</p>}
+      <form onSubmit={handleSubmit}>
+        <div className="form-group">
+          <label htmlFor="team-name">Team Name *</label>
+          <input
+            id="team-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+          />
+        </div>
+
+        <p>Select up to 6 Pokémon builds</p>
+        {availableBuilds.length === 0 ? (
+          <p>You have no builds available. Create one first.</p>
+        ) : (
+          <div className="pokedex-grid select-builds-grid">
+            {availableBuilds.map((build) => {
+              const selected = selectedBuilds.includes(build._id);
+              return (
+                <div
+                  key={build._id}
+                  className={`pokedex-card selectable ${selected ? 'selected' : ''}`}
+                  onClick={() => toggleSelect(build._id)}
+                >
+                  <div className="pokedex-image-container">
+                    <img
+                      className="pokemon-image"
+                      src={getSpriteUrl(build.species)}
+                      alt={build.species}
+                    />
+                  </div>
+                  <div className="pokedex-info">
+                    <h3 className="pokemon-nickname">{build.nickname || 'Unnamed Build'}</h3>
+                    <h4 className="pokemon-species">{capitalize(build.species)}</h4>
+
+                    <div className="pokedex-details">
+                      <div className="pokedex-types">
+                        <span className="pokemon-nature">Nature: {capitalize(build.nature || '')}</span>
+                        <span className="pokemon-ability">Ability: {capitalize(build.ability || '')}</span>
+                      </div>
+
+                      <div className="pokedex-stats">
+                        <div className="stat-bar">
+                          <span className="stat-label">HP</span>
+                          <div className="stat-bar-container">
+                            <div className="stat-fill stat-fill-hp" style={{width: `${(build.stats.hp / 255) * 100}%`}}></div>
+                            <span className="stat-value">{build.stats.hp}</span>
+                          </div>
+                        </div>
+                        <div className="stat-bar">
+                          <span className="stat-label">ATK</span>
+                          <div className="stat-bar-container">
+                            <div className="stat-fill stat-fill-attack" style={{width: `${(build.stats.attack / 255) * 100}%`}}></div>
+                            <span className="stat-value">{build.stats.attack}</span>
+                          </div>
+                        </div>
+                        <div className="stat-bar">
+                          <span className="stat-label">DEF</span>
+                          <div className="stat-bar-container">
+                            <div className="stat-fill stat-fill-defense" style={{width: `${(build.stats.defense / 255) * 100}%`}}></div>
+                            <span className="stat-value">{build.stats.defense}</span>
+                          </div>
+                        </div>
+                        <div className="stat-bar">
+                          <span className="stat-label">SP-A</span>
+                          <div className="stat-bar-container">
+                            <div className="stat-fill stat-fill-special-attack" style={{width: `${(build.stats.specialAttack / 255) * 100}%`}}></div>
+                            <span className="stat-value">{build.stats.specialAttack}</span>
+                          </div>
+                        </div>
+                        <div className="stat-bar">
+                          <span className="stat-label">SP-D</span>
+                          <div className="stat-bar-container">
+                            <div className="stat-fill stat-fill-special-defense" style={{width: `${(build.stats.specialDefense / 255) * 100}%`}}></div>
+                            <span className="stat-value">{build.stats.specialDefense}</span>
+                          </div>
+                        </div>
+                        <div className="stat-bar">
+                          <span className="stat-label">SPEED</span>
+                          <div className="stat-bar-container">
+                            <div className="stat-fill stat-fill-speed" style={{width: `${(build.stats.speed / 255) * 100}%`}}></div>
+                            <span className="stat-value">{build.stats.speed}</span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="pokedex-moves">
+                      <h4>Moves</h4>
+                      {build.moves && build.moves.length > 0 && (
+                        <div className="move-list">
+                          {build.moves.map((move, index) => (
+                            <span key={index} className="move-tag">
+                              {move ? capitalize(move) : 'Unknown'}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        <button type="submit" className="submit-button">
+          Save Team
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default CreateTeam;

--- a/src/pages/EditTeam.jsx
+++ b/src/pages/EditTeam.jsx
@@ -1,0 +1,138 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useAuth } from '../provider/authProvider';
+import api from '../services/api';
+import '../styles/EditTeam.css';
+
+const EditTeam = () => {
+  const { id } = useParams(); // team id
+  const { token } = useAuth();
+  const navigate = useNavigate();
+
+  const [team, setTeam] = useState(null);
+  const [availableBuilds, setAvailableBuilds] = useState([]);
+  const [selectedBuild, setSelectedBuild] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  // Helper to fetch latest team and available builds
+  const fetchData = async () => {
+    try {
+      setLoading(true);
+      api.defaults.headers.common['Authorization'] = `Bearer ${token}`;
+
+      // Fetch team details
+      const teamRes = await api.get(`/teams/${id}`);
+      setTeam(teamRes.data.data);
+
+      // Fetch builds not already in team
+      const availRes = await api.get(`/teams/${id}/available-builds`);
+      setAvailableBuilds(availRes.data.data);
+    } catch (err) {
+      console.error(err);
+      setError('Failed to load team data');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
+
+  const handleAdd = async () => {
+    if (!selectedBuild) return;
+    try {
+      setLoading(true);
+      await api.post(`/teams/${id}/pokemon/${selectedBuild}`);
+      setSelectedBuild('');
+      await fetchData();
+    } catch (err) {
+      console.error(err);
+      alert('Failed to add Pokémon to team');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Remove build from team
+  const handleRemove = async (buildId) => {
+    if (window.confirm('Remove this Pokémon from the team?')) {
+      try {
+        setLoading(true);
+        await api.delete(`/teams/${id}/pokemon/${buildId}`);
+        await fetchData();
+      } catch (err) {
+        console.error(err);
+        alert('Failed to remove Pokémon from team');
+      } finally {
+        setLoading(false);
+      }
+    }
+  };
+
+  const getSpriteUrl = (species) =>
+    `https://play.pokemonshowdown.com/sprites/ani/${species.toLowerCase()}.gif`;
+
+  if (loading) {
+    return (
+      <div className="loading-container">
+        <div className="loading-spinner"></div>
+        <p>Loading team...</p>
+      </div>
+    );
+  }
+
+  if (error) return <p className="error">{error}</p>;
+  if (!team) return null;
+
+  return (
+    <div className="edit-team-container">
+      <h2>Edit Team – {team.name}</h2>
+
+      <div className="team-pokemon">
+        {team.pokemonBuilds.map((build) => (
+          <div key={build._id} className="team-slot">
+            <img
+              className="team-pokemon-image"
+              src={getSpriteUrl(build.species)}
+              alt={build.species}
+            />
+            <button
+              className="remove-button"
+              onClick={() => handleRemove(build._id)}
+            >
+              Remove
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {team.pokemonBuilds.length < 6 && (
+        <div className="add-section">
+          <select
+            value={selectedBuild}
+            onChange={(e) => setSelectedBuild(e.target.value)}
+          >
+            <option value="">Select build to add</option>
+            {availableBuilds.map((build) => (
+              <option key={build._id} value={build._id}>
+                {build.nickname || build.species}
+              </option>
+            ))}
+          </select>
+          <button className="add-button" onClick={handleAdd} disabled={!selectedBuild}>
+            Add
+          </button>
+        </div>
+      )}
+
+      <button className="back-button" onClick={() => navigate('/teams')}>
+        ← Back to Teams
+      </button>
+    </div>
+  );
+};
+
+export default EditTeam;

--- a/src/pages/Teams.jsx
+++ b/src/pages/Teams.jsx
@@ -1,0 +1,128 @@
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../provider/authProvider';
+import api from '../services/api';
+import '../styles/Teams.css';
+
+const Teams = () => {
+  const { token } = useAuth();
+  const [teams, setTeams] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchTeams = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        // Configure auth header
+        api.defaults.headers.common['Authorization'] = `Bearer ${token}`;
+
+        // Fetch teams from API
+        const response = await api.get('/teams');
+        setTeams(response.data.data);
+      } catch (err) {
+        console.error('Error fetching teams:', err);
+        setError('Failed to load your Pokémon teams');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchTeams();
+  }, [token]);
+
+  // Delete a team
+  const handleDeleteTeam = async (teamId) => {
+    if (window.confirm('Are you sure you want to delete this team?')) {
+      try {
+        api.defaults.headers.common['Authorization'] = `Bearer ${token}`;
+        await api.delete(`/teams/${teamId}`);
+        setTeams(teams.filter((team) => team._id !== teamId));
+      } catch (err) {
+        console.error('Error deleting team:', err);
+        alert('Failed to delete team. Please try again.');
+      }
+    }
+  };
+
+  // Helper to get Pokémon sprite URL
+  const getSpriteUrl = (species) =>
+    `https://play.pokemonshowdown.com/sprites/ani/${species.toLowerCase()}.gif`;
+
+  return (
+    <div className="teams-container">
+      <div className="teams-header">
+        <div>
+          <h1>My Pokémon Teams</h1>
+          <p>View and manage your custom Pokémon teams</p>
+        </div>
+        <Link to="/teams/create" className="create-team-btn">Create New Team</Link>
+      </div>
+
+      {loading && (
+        <div className="loading-container">
+          <div className="loading-spinner"></div>
+          <p>Loading your teams...</p>
+        </div>
+      )}
+
+      {!loading && error && (
+        <div className="empty-teams error-state">
+          <h3>{error}</h3>
+          <p>There was a problem loading your teams. Please try again later.</p>
+        </div>
+      )}
+
+      {!loading && !error && teams.length === 0 && (
+        <div className="empty-teams">
+          <h3>You don't have any Pokémon teams yet!</h3>
+          <p>Create your first team to get started!</p>
+          <Link to="/teams/create" className="create-team-btn">Create New Team</Link>
+        </div>
+      )}
+
+      {!loading && !error && teams.length > 0 && (
+        <div className="team-grid">
+          {teams.map((team) => (
+            <div key={team._id} className="team-card">
+              <h3 className="team-name">{team.name}</h3>
+              <div className="team-pokemon">
+                {[...Array(6)].map((_, idx) => {
+                  const build = team.pokemonBuilds[idx];
+                  return (
+                    <div key={idx} className="team-slot">
+                      {build ? (
+                        <img
+                          className="team-pokemon-image"
+                          src={getSpriteUrl(build.species)}
+                          alt={build.species}
+                        />
+                      ) : (
+                        <div className="empty-slot">+</div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+              <div className="team-buttons">
+                <Link to={`/teams/${team._id}/edit`} className="edit-button">
+                  Edit
+                </Link>
+                <button
+                  className="delete-button"
+                  onClick={() => handleDeleteTeam(team._id)}
+                >
+                  ×
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Teams;

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -10,6 +10,9 @@ import Dashboard from "../pages/Dashboard";
 import Builds from "../pages/Builds";
 import CreateBuild from "../pages/CreateBuild";
 import EditBuild from "../pages/EditBuild";
+import Teams from "../pages/Teams";
+import EditTeam from "../pages/EditTeam";
+import CreateTeam from "../pages/CreateTeam";
 
 const Routes = () => {
   const { token } = useAuth();
@@ -44,6 +47,9 @@ const Routes = () => {
             { path: "builds", element: <Builds /> },
             { path: "builds/create", element: <CreateBuild /> },
             { path: "builds/:id/edit", element: <EditBuild /> },
+            { path: "teams", element: <Teams /> },
+            { path: "teams/:id/edit", element: <EditTeam /> },
+            { path: "teams/create", element: <CreateTeam /> },
             { path: "logout", element: <Logout /> },
             
           ],

--- a/src/styles/Builds.css
+++ b/src/styles/Builds.css
@@ -20,6 +20,7 @@
     font-size: 1.1rem;
     color: #1e293b; 
     font-weight: bold;
+    margin-bottom: 2rem;
   }
   
   /*  Grid Layout  */

--- a/src/styles/CreateTeam.css
+++ b/src/styles/CreateTeam.css
@@ -1,0 +1,110 @@
+.create-team-container {
+  padding: 2rem;
+  max-width: 900px;
+  margin: 0 auto;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+.create-team-container h2 {
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+.form-group {
+  margin-bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.form-group label {
+  margin-bottom: 0.25rem;
+  font-weight: bold;
+  color: #1e293b;
+}
+
+.form-group input {
+  padding: 0.5rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  margin: 0 auto; 
+  display: block; 
+}
+
+.builds-select-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.select-builds-grid {
+  margin-bottom: 1.5rem;
+}
+
+.build-card-select {
+  background-color: #f8fafc;
+  border: 2px solid transparent;
+  border-radius: 8px;
+  padding: 0.5rem;
+  text-align: center;
+  cursor: pointer;
+  transition: border-color 0.2s;
+}
+
+.build-card-select.selected {
+  border-color: #3b82f6;
+}
+
+.build-card-select img {
+  width: 96px;
+  height: auto;
+  image-rendering: pixelated;
+}
+
+.pokedex-card.selectable {
+  cursor: pointer;
+  transition: border 0.2s, box-shadow 0.2s;
+}
+
+.pokedex-card.selectable.selected {
+  border: 5px solid #16a34a;
+}
+
+.pokedex-card.selectable:hover {
+  transform: translateY(-5px);
+}
+
+.submit-button {
+  display: block;
+  margin: 0 auto;
+  background-color: #16a34a;
+  color: white;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.loading-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.loading-spinner {
+  width: 40px;
+  height: 40px;
+  border: 4px solid #cbd5e1;
+  border-top-color: #3b82f6;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin-bottom: 1rem;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/styles/EditTeam.css
+++ b/src/styles/EditTeam.css
@@ -1,0 +1,100 @@
+.edit-team-container {
+  padding: 2rem;
+  max-width: 800px;
+  margin: 0 auto;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+.edit-team-container h2 {
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+.team-pokemon {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-bottom: 1.5rem;
+}
+
+.team-slot {
+  position: relative;
+  width: 96px;
+  height: 96px;
+  border: 1px dashed #cbd5e1;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #f8fafc;
+}
+
+.team-pokemon-image {
+  width: 90px;
+  height: auto;
+  image-rendering: pixelated;
+}
+
+.remove-button {
+  position: absolute;
+  bottom: 4px;
+  right: 4px;
+  background-color: rgba(190, 21, 21, 0.555);
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 0.7rem;
+  padding: 2px 4px;
+  cursor: pointer;
+}
+
+.add-section {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  margin-bottom: 2rem;
+}
+
+.add-button {
+  background-color: #16a34a;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.back-button {
+  display: block;
+  margin: 0 auto;
+  background: none;
+  border: none;
+  color: #1e293b;
+  font-size: 1rem;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.loading-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.loading-spinner {
+  width: 40px;
+  height: 40px;
+  border: 4px solid #cbd5e1;
+  border-top-color: #3b82f6;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin-bottom: 1rem;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/styles/Teams.css
+++ b/src/styles/Teams.css
@@ -1,0 +1,167 @@
+.teams-container {
+  padding: 2rem;
+  min-height: 100vh;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+.teams-header {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+.teams-header p {
+  margin-bottom: 2rem;
+}
+
+.teams-header h1 {
+  font-size: 2.5rem;
+  color: #1e293b;
+  margin-bottom: 0.5rem;
+}
+
+.teams-header p {
+  font-size: 1.1rem;
+  color: #1e293b;
+  font-weight: bold;
+}
+
+.team-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1.5rem;
+}
+
+.team-card {
+  background-color: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+}
+
+.team-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.12);
+}
+
+.team-name {
+  margin: 0 0 1rem 0;
+  font-size: 1.4rem;
+  color: #1e293b;
+}
+
+.team-pokemon {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.team-slot {
+  width: 80px;
+  height: 80px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: 1px dashed #cbd5e1;
+  border-radius: 8px;
+  background-color: #f8fafc;
+  position: relative;
+}
+
+.team-pokemon-image {
+  width: 72px;
+  height: auto;
+  image-rendering: pixelated;
+}
+
+.empty-slot {
+  font-size: 2rem;
+  color: #94a3b8;
+}
+
+.team-buttons {
+  margin-top: 1rem;
+  display: flex;
+  gap: 2rem;
+}
+
+.create-team-btn {
+    margin-top: 1.5rem;
+    background-color: #16a34a;
+    color: white;
+    border: none;
+    padding: 0.75rem 1.5rem;
+    border-radius: 8px;
+    font-size: 1rem;
+    font-weight: bold;
+    cursor: pointer;
+    transition: background-color 0.2s;
+  }
+  
+  .create-team-btn:hover {
+    background-color: #15803d;
+  }
+
+.edit-button {
+  background-color: #3b82f6;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: bold;
+  transition: background-color 0.2s;
+}
+
+.edit-button:hover {
+  background-color: #2563eb;
+}
+
+.delete-button {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  border: none;
+  background-color: rgba(190, 21, 21, 0.555);
+  color: #475569;
+  font-size: 1.2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color 0.2s, color 0.2s;
+}
+
+.delete-button:hover {
+  background-color: #ef4444;
+  color: white;
+}
+
+/* Responsive Design */
+@media (max-width: 1200px) {
+  .team-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 900px) {
+  .team-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 600px) {
+  .teams-container {
+    padding: 1rem;
+  }
+  .teams-header h1 {
+    font-size: 2rem;
+  }
+  .team-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
Pokémon Team Management features with Create, Read, Update, and Delete functionality.

Features

-CreateTeam Form to name a team and select up to 6 builds
- Teams: Grid display of teams with edit/delete options
- EditTeam Add/remove builds dynamically (max 6), synced with backend

Styling

- Added `Teams.css`, `CreateTeam.css`, `EditTeam.css` for layout and interaction
- Responsive design and visual feedback for selected builds
- Loading and error states handled

Integration

- New routes added to index.jsx

Tested locally for form validation, layout, and API interactions.
